### PR TITLE
Compare last two prs for error

### DIFF
--- a/INPUT.json
+++ b/INPUT.json
@@ -1,24 +1,8 @@
 {
-  "urls": [
-    {
-      "url": "https://www.apify.com/change-log",
-      "contentSelector": "main",
-      "screenshotSelector": "main",
-      "sendNotificationText": "Apify changelog updated!"
-    },
-    {
-      "url": "https://github.com/apify/apify-cli",
-      "contentSelector": ".repository-content",
-      "screenshotSelector": ".repository-content",
-      "sendNotificationText": "Apify CLI repository updated!"
-    },
-    {
-      "url": "https://example.com",
-      "contentSelector": "body",
-      "screenshotSelector": "body",
-      "sendNotificationText": "Example page changed!"
-    }
-  ],
+  "urls": "https://www.apify.com/change-log\nhttps://github.com/apify/apify-cli\nhttps://example.com",
+  "contentSelector": "article",
+  "screenshotSelector": "article",
+  "sendNotificationText": "Content changed!",
   "sendNotificationTo": "test@example.com",
   "informOnError": "email",
   "navigationTimeout": 30000,

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,10 @@ export interface UrlConfig {
 }
 
 export interface Input {
-    urls: UrlConfig[];
+    urls: string;
+    contentSelector: string;
+    screenshotSelector?: string;
+    sendNotificationText?: string;
     sendNotificationTo: string;
     navigationTimeout?: number;
     informOnError: string;
@@ -24,40 +27,32 @@ export interface Input {
 
 await Actor.init();
 
-// Try to get input from Actor.getInput(), fallback to reading INPUT.json file for local development
-let input: Input;
-try {
-    const inputRaw = await Actor.getInput();
-    
-    // Check if we got a valid input (not a character array)
-    if (inputRaw && typeof inputRaw === 'object' && !Object.keys(inputRaw).every(key => /^\d+$/.test(key))) {
-        input = inputRaw as Input;
-    } else {
-        throw new Error('Invalid input from Actor.getInput()');
-    }
-} catch (error) {
-    // Fallback: read from INPUT.json file for local development
-    const fs = await import('fs/promises');
-    const path = await import('path');
-    const inputPath = path.join(process.cwd(), 'INPUT.json');
-    try {
-        const inputFile = await fs.readFile(inputPath, 'utf-8');
-        input = JSON.parse(inputFile) as Input;
-    } catch (fileError) {
-        throw new Error('Could not read input from Actor.getInput() or INPUT.json file');
-    }
-}
+const input = await Actor.getInput() as Input;
 
 await validateInput(input);
 
 const {
-    urls,
+    urls: urlsString,
+    contentSelector,
+    screenshotSelector = contentSelector,
+    sendNotificationText,
     sendNotificationTo,
     navigationTimeout = 30000,
     informOnError,
     maxRetries = 5,
     retryStrategy = 'on-block', // 'on-block', 'on-all-errors', 'never-retry'
 } = input;
+
+// Parse URLs string into array (split by newlines and filter empty lines)
+const urlStrings = urlsString.split('\n').map(url => url.trim()).filter(url => url.length > 0);
+
+// Convert string URLs to UrlConfig objects
+const urls: UrlConfig[] = urlStrings.map(url => ({
+    url,
+    contentSelector,
+    screenshotSelector,
+    sendNotificationText
+}));
 
 // define name for a key-value store based on task ID or actor ID
 // (to be able to have more content checkers under one Apify account)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,8 +43,12 @@ export const screenshotDOMElement = async (page: Page, selector: string, padding
 
 export const validateInput = async (input: Input) => {
     // check inputs
-    if (!input || !input.urls || !Array.isArray(input.urls) || input.urls.length === 0) {
-        await Actor.fail('Invalid input: Input must be a JSON object with a "urls" array containing at least one URL object!');
+    if (!input || !input.urls || typeof input.urls !== 'string' || input.urls.trim().length === 0) {
+        await Actor.fail('Invalid input: Input must be a JSON object with a "urls" string containing at least one URL!');
+    }
+    
+    if (!input.contentSelector) {
+        await Actor.fail('Invalid input: "contentSelector" field is required!');
     }
     
     if (!input.sendNotificationTo) {
@@ -55,19 +59,15 @@ export const validateInput = async (input: Input) => {
         await Actor.fail('Invalid input: "informOnError" field is required!');
     }
     
-    // Validate each URL object
-    for (let i = 0; i < input.urls.length; i++) {
-        const urlConfig = input.urls[i];
-        if (!urlConfig.url) {
-            await Actor.fail(`Invalid input: URL object at index ${i} is missing "url" field!`);
-        }
-        if (!urlConfig.contentSelector) {
-            await Actor.fail(`Invalid input: URL object at index ${i} is missing "contentSelector" field!`);
-        }
+    // Validate that URLs are valid
+    const urlStrings = input.urls.split('\n').map(url => url.trim()).filter(url => url.length > 0);
+
+    for (let i = 0; i < urlStrings.length; i++) {
+        const url = urlStrings[i];
         try {
-            new URL(urlConfig.url);
+            new URL(url);
         } catch (error) {
-            await Actor.fail(`Invalid input: URL at index ${i} is not valid: ${urlConfig.url}`);
+            await Actor.fail(`Invalid input: URL at line ${i + 1} is not valid: ${url}`);
         }
     }
 };


### PR DESCRIPTION
Revert URL input format to a single newline-separated string to restore previous functionality.

The previous PR introduced a breaking change by modifying the `urls` input from a string of newline-separated URLs to an array of objects, which caused an "Invalid input" error for existing users. This PR restores the original input structure and associated validation logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-33cd5a88-bbcc-4296-a7e7-5e46484ed45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33cd5a88-bbcc-4296-a7e7-5e46484ed45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

